### PR TITLE
fix: highlight regex quantifiers correctly

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/nusnewob/caddyfile-zed"
 
 [grammars.caddyfile]
 repository = "https://github.com/nusnewob/tree-sitter-caddyfile.git"
-commit = "9d3af6ae44ea5f9015bc2c9a5a02066c192ab627"
+commit = "8e9e4502d6495302137cb5671dbe3cb7c47ca7b6"


### PR DESCRIPTION
Update the grammar to parse regex punctuation and quantifiers such as `{1,128}` without breaking highlighting.

Depends on nusnewob/tree-sitter-caddyfile#1.